### PR TITLE
Include example of ! to ignore errors for a command

### DIFF
--- a/QBNDSRC/SAMPLE.BNDDIR
+++ b/QBNDSRC/SAMPLE.BNDDIR
@@ -1,7 +1,7 @@
      
 /* Have to delete the BNDDIR, or it will always be older than the source */
 /* because the CRTBNDDIR will fail the second time and only the ADDBNDDIRE is executed */     
-DLTOBJ OBJ(&O/&N) OBJTYPE(*BNDDIR)
+!DLTOBJ OBJ(&O/&N) OBJTYPE(*BNDDIR)
 CRTBNDDIR BNDDIR(&O/&N)
 ADDBNDDIRE BNDDIR(&O/&N) +
    OBJ((*LIBL/XML *SRVPGM) (*LIBL/ORDER *SRVPGM) (*LIBL/TXT *SRVPGM) +


### PR DESCRIPTION
With the release of https://github.com/IBM/ibmi-bob v2.4.30, we can now include an example of the usage of ! as discussed in https://github.com/IBM/ibmi-bob/pull/317